### PR TITLE
feat: new babel plugin with component metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ No additional configuration is required. The plugin is automatically discovered 
 
 ## Requirements
 
-- React Native 0.76+
-- React 18+
+- React Native 0.79+
+- React 19+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -74,4 +74,3 @@ export default function App() {
 ## License
 
 MIT
-```

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ npm install --save-dev rozenite-preview@alpha
 yarn add -D rozenite-preview@alpha
 ```
 
+## Configuration
+
+Add the following to your `babel.config.js` to get more insights and metadata in your previews:
+
+```js
+module.exports = {
+  presets: ["module:metro-react-native-babel-preset"],
+  plugins: ["rozenite-preview/babel-plugin"]
+};
+```
+
 ## Usage
 
 1. **Register your components for preview:**
@@ -39,20 +50,16 @@ registerPreview("UserCard", UserCard);
 import { PreviewHost } from "rozenite-preview";
 
 export default function App() {
-  return (
-    <PreviewHost>
-      {/* your app */}
-    </PreviewHost>
-  );
+  return <PreviewHost>{/* your app */}</PreviewHost>;
 }
 ```
 
 3. **Open React Native DevTools and use the "Preview" panel**  
-Select and interact with your registered components in real time.
+   Select and interact with your registered components in real time.
 
-## Configuration
+## Known Issues
 
-No additional configuration is required. The plugin is automatically discovered by Rozenite when installed.
+- **HMR Support**: Hot Module Replacement (HMR) is not fully supported yet. You need to refresh the DevTools to see changes in deleted previews. Adding or modifying previews works for now.
 
 ## API
 
@@ -67,3 +74,4 @@ No additional configuration is required. The plugin is automatically discovered 
 ## License
 
 MIT
+```

--- a/babel-plugin/preview-babel-plugin-metadata.cjs
+++ b/babel-plugin/preview-babel-plugin-metadata.cjs
@@ -1,5 +1,6 @@
 const path = require("path");
 const crypto = require("crypto");
+const { isInsideReactComponent } = require("./react-helper.cjs");
 
 /**
  * Babel plugin that automatically that injects the file path and other metadata
@@ -120,6 +121,10 @@ function injectFilePathIntoRegisterPreviewCalls(
           t.objectProperty(
             t.identifier("relativeFilename"),
             t.stringLiteral(relativeFilename)
+          ),
+          t.objectProperty(
+            t.identifier("isInsideReactComponent"),
+            t.booleanLiteral(isInsideReactComponent(callPath))
           ),
           t.objectProperty(
             t.identifier("name"),

--- a/babel-plugin/preview-babel-plugin-metadata.cjs
+++ b/babel-plugin/preview-babel-plugin-metadata.cjs
@@ -3,7 +3,7 @@ const crypto = require("crypto");
 const { isInsideReactComponent } = require("./react-helper.cjs");
 
 /**
- * Babel plugin that automatically that injects the file path and other metadata
+ * Babel plugin that automatically injects the file path and other metadata
  * to registerPreview() calls imported from "rozenite-preview"
  */
 const ROZENITE_PREVIEW_MODULE = "rozenite-preview";
@@ -201,9 +201,6 @@ function getMetadata(callPath) {
   } else if (firstArg && firstArg.type === "Identifier") {
     name = `<dynamic:${firstArg.name}>`;
     nameType = "identifier";
-  } else if (firstArg && firstArg.type === "TemplateLiteral") {
-    name = `<template:${getTemplateLiteralId(firstArg)}>`;
-    nameType = "template";
   }
 
   // Create a unique identifier for this specific call

--- a/babel-plugin/preview-babel-plugin-metadata.cjs
+++ b/babel-plugin/preview-babel-plugin-metadata.cjs
@@ -1,0 +1,241 @@
+const path = require("path");
+const crypto = require("crypto");
+
+/**
+ * Babel plugin that automatically injects the current file path as a third argument
+ * to registerPreview() calls imported from "rozenite-preview"
+ */
+const ROZENITE_PREVIEW_MODULE = "rozenite-preview";
+const TARGET_FUNCTION = "registerPreview";
+const EXPECTED_ARGS_COUNT = 2;
+
+const cache = {};
+
+function getOrCreateId(file, line) {
+  const key = `${file}:${line}`;
+  if (cache[key]) return cache[key];
+
+  const hash = crypto.createHash("md5").update(key).digest("hex").slice(0, 6);
+  const id = `${path
+    .basename(file, path.extname(file))
+    .toLowerCase()}_${line}_${hash}`;
+  cache[key] = id;
+  return id;
+}
+
+module.exports = function ({ types: t }) {
+  return {
+    visitor: {
+      Program(path, state) {
+        const rozenitePreviewImports = collectRozeniteImports(path, t);
+
+        if (rozenitePreviewImports.size === 0) {
+          return;
+        }
+
+        injectFilePathIntoRegisterPreviewCalls(
+          path,
+          state,
+          rozenitePreviewImports,
+          t
+        );
+      },
+    },
+  };
+};
+
+/**
+ * Collects all identifiers imported from "rozenite-preview"
+ * @param {Object} programPath - The program AST path
+ * @param {Object} t - Babel types helper
+ * @returns {Set} Set of imported identifier names
+ */
+function collectRozeniteImports(programPath, t) {
+  const imports = new Set();
+
+  programPath.get("body").forEach((statement) => {
+    if (!isRozeniteImportDeclaration(statement)) {
+      return;
+    }
+
+    statement.node.specifiers.forEach((specifier) => {
+      if (isValidImportSpecifier(specifier, t)) {
+        imports.add(specifier.local.name);
+      }
+    });
+  });
+
+  return imports;
+}
+
+/**
+ * Checks if a statement is an import from "rozenite-preview"
+ * @param {Object} statement - AST statement node
+ * @returns {boolean}
+ */
+function isRozeniteImportDeclaration(statement) {
+  return (
+    statement.isImportDeclaration() &&
+    statement.node.source.value === ROZENITE_PREVIEW_MODULE
+  );
+}
+
+/**
+ * Checks if a specifier is a valid import specifier (named or default)
+ * @param {Object} specifier - Import specifier node
+ * @param {Object} t - Babel types helper
+ * @returns {boolean}
+ */
+function isValidImportSpecifier(specifier, t) {
+  return (
+    t.isImportSpecifier(specifier) || t.isImportDefaultSpecifier(specifier)
+  );
+}
+
+/**
+ * Traverses the AST and injects file paths into registerPreview calls
+ * @param {Object} programPath - The program AST path
+ * @param {Object} state - Babel plugin state
+ * @param {Set} rozeniteImports - Set of imported identifiers from rozenite-preview
+ * @param {Object} t - Babel types helper
+ */
+function injectFilePathIntoRegisterPreviewCalls(
+  programPath,
+  state,
+  rozeniteImports,
+  t
+) {
+  const filename = state.file.opts.filename || "";
+  const relativeFilename = path.relative(process.cwd(), filename);
+
+  console.log(
+    "Traversing AST to inject file path and detail into registerPreview calls...",
+    {
+      filename,
+      relativeFilename,
+    }
+  );
+
+  programPath.traverse({
+    CallExpression(callPath) {
+      if (isTargetRegisterPreviewCall(callPath, rozeniteImports)) {
+        const metadata = getMetadata(callPath);
+        const filePath = t.stringLiteral(filename);
+        const id = getOrCreateId(relativeFilename, metadata.line);
+        const argument = t.objectExpression([
+          t.objectProperty(t.identifier("id"), t.stringLiteral(id)),
+          t.objectProperty(t.identifier("filePath"), filePath),
+          t.objectProperty(
+            t.identifier("relativeFilename"),
+            t.stringLiteral(relativeFilename)
+          ),
+          t.objectProperty(
+            t.identifier("name"),
+            t.stringLiteral(metadata.name)
+          ),
+          t.objectProperty(
+            t.identifier("nameType"),
+            t.stringLiteral(metadata.nameType)
+          ),
+          t.objectProperty(
+            t.identifier("callId"),
+            t.stringLiteral(metadata.callId)
+          ),
+          t.objectProperty(
+            t.identifier("componentType"),
+            t.stringLiteral(metadata.componentType)
+          ),
+          t.objectProperty(
+            t.identifier("timestamp"),
+            t.numericLiteral(metadata.timestamp)
+          ),
+          t.objectProperty(
+            t.identifier("line"),
+            t.numericLiteral(metadata.line)
+          ),
+          t.objectProperty(
+            t.identifier("column"),
+            t.numericLiteral(metadata.column)
+          ),
+        ]);
+        callPath.node.arguments.push(argument);
+      }
+    },
+  });
+}
+
+/**
+ * Determines the component type from the second argument
+ * @param {Object} componentArg - Component argument AST node
+ * @returns {string} Component type description
+ */
+function getComponentType(componentArg) {
+  if (!componentArg) return "unknown";
+
+  switch (componentArg.type) {
+    case "Identifier":
+      return `component:${componentArg.name}`;
+    case "ArrowFunctionExpression":
+    case "FunctionExpression":
+      return "inline-function";
+    case "CallExpression":
+      return "call-expression";
+    default:
+      return componentArg.type.toLowerCase();
+  }
+}
+
+/**
+ * Extracts detailed information from a registerPreview call
+ * @param {Object} callPath - The call expression AST path
+ * @returns {Object} Preview details including name, location, and arguments
+ */
+function getMetadata(callPath) {
+  const firstArg = callPath.node.arguments[0];
+  const secondArg = callPath.node.arguments[1];
+  const loc = callPath.node.loc;
+
+  let name = null;
+  let nameType = "unknown";
+
+  if (firstArg && firstArg.type === "StringLiteral") {
+    name = firstArg.value;
+    nameType = "literal";
+  } else if (firstArg && firstArg.type === "Identifier") {
+    name = `<dynamic:${firstArg.name}>`;
+    nameType = "identifier";
+  } else if (firstArg && firstArg.type === "TemplateLiteral") {
+    name = `<template:${getTemplateLiteralId(firstArg)}>`;
+    nameType = "template";
+  }
+
+  // Create a unique identifier for this specific call
+  const callId = `${name}:${loc?.start?.line || 0}:${loc?.start?.column || 0}`;
+
+  return {
+    name,
+    nameType,
+    callId,
+    line: loc?.start?.line || 0,
+    column: loc?.start?.column || 0,
+    componentType: getComponentType(secondArg),
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * Determines if a call expression is a registerPreview call that needs modification
+ * @param {Object} callPath - The call expression AST path
+ * @param {Set} rozeniteImports - Set of imported identifiers from rozenite-preview
+ * @returns {boolean}
+ */
+function isTargetRegisterPreviewCall(callPath, rozeniteImports) {
+  const callee = callPath.get("callee");
+
+  return (
+    callee.isIdentifier() &&
+    callee.node.name === TARGET_FUNCTION &&
+    rozeniteImports.has(callee.node.name) &&
+    callPath.node.arguments.length === EXPECTED_ARGS_COUNT
+  );
+}

--- a/babel-plugin/preview-babel-plugin-metadata.cjs
+++ b/babel-plugin/preview-babel-plugin-metadata.cjs
@@ -143,10 +143,6 @@ function injectFilePathIntoRegisterPreviewCalls(
             t.stringLiteral(metadata.componentType)
           ),
           t.objectProperty(
-            t.identifier("timestamp"),
-            t.numericLiteral(metadata.timestamp)
-          ),
-          t.objectProperty(
             t.identifier("line"),
             t.numericLiteral(metadata.line)
           ),
@@ -213,7 +209,6 @@ function getMetadata(callPath) {
     line: loc?.start?.line || 0,
     column: loc?.start?.column || 0,
     componentType: getComponentType(secondArg),
-    timestamp: Date.now(),
   };
 }
 

--- a/babel-plugin/react-helper.cjs
+++ b/babel-plugin/react-helper.cjs
@@ -1,0 +1,100 @@
+function hasJSXInFunction(functionPath) {
+  let hasJSX = false;
+  functionPath.traverse({
+    JSXElement() {
+      hasJSX = true;
+    },
+    JSXFragment() {
+      hasJSX = true;
+    },
+  });
+  return hasJSX;
+}
+
+function isInsideJSXExpression(path) {
+  return (
+    path.findParent(
+      (parent) =>
+        parent.isJSXExpressionContainer() ||
+        parent.isJSXElement() ||
+        parent.isJSXFragment()
+    ) !== null
+  );
+}
+
+function isInsideReactComponent(path) {
+  if (!path.isCallExpression()) return false;
+
+  // Check if inside JSX
+  if (isInsideJSXExpression(path)) return true;
+
+  const functionParent = path.getFunctionParent();
+  if (!functionParent) return false;
+
+  // React hooks pattern
+  if (isInsideReactHook(path)) return true;
+
+  // Class component lifecycle methods
+  if (functionParent.isClassMethod()) {
+    const methodName = functionParent.node.key?.name;
+    const reactMethods = [
+      "render",
+      "componentDidMount",
+      "componentDidUpdate",
+      "componentWillUnmount",
+      "getSnapshotBeforeUpdate",
+      "componentDidCatch",
+      "getDerivedStateFromError",
+      "shouldComponentUpdate",
+      "getInitialState",
+    ];
+    return reactMethods.includes(methodName);
+  }
+
+  // Functional component (function that returns JSX)
+  if (functionParent.isFunction()) {
+    return isLikelyFunctionalComponent(functionParent);
+  }
+
+  return false;
+}
+
+function isInsideReactHook(path) {
+  return (
+    path.findParent((parent) => {
+      if (!parent.isCallExpression()) return false;
+      const callee = parent.node.callee;
+      if (callee.type !== "Identifier") return false;
+      return /^use[A-Z]/.test(callee.name);
+    }) !== null
+  );
+}
+
+function isLikelyFunctionalComponent(functionPath) {
+  // Check if function name starts with capital letter (component convention)
+  const functionName = functionPath.node.id?.name;
+  if (functionName && /^[A-Z]/.test(functionName)) {
+    return hasJSXInFunction(functionPath);
+  }
+
+  // Check if assigned to a variable with capital letter
+  if (
+    functionPath.isArrowFunctionExpression() ||
+    functionPath.isFunctionExpression()
+  ) {
+    const parent = functionPath.parent;
+    if (
+      parent.type === "VariableDeclarator" &&
+      parent.id.name &&
+      /^[A-Z]/.test(parent.id.name)
+    ) {
+      return hasJSXInFunction(functionPath);
+    }
+  }
+
+  return false;
+}
+
+module.exports = {
+  isInsideReactComponent,
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,14 @@
   "main": "./dist/react-native.cjs",
   "module": "./dist/react-native.js",
   "types": "./dist/react-native.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/react-native.js",
+      "require": "./dist/react-native.cjs",
+      "types": "./dist/react-native.d.ts"
+    },
+    "./babel-plugin": "./babel-plugin/preview-babel-plugin-metadata.cjs"
+  },
   "scripts": {
     "prepublishOnly": "bun run build",
     "semantic-release": "semantic-release",

--- a/src/react-native/preview-host.tsx
+++ b/src/react-native/preview-host.tsx
@@ -9,7 +9,15 @@ interface PreviewHostProps {
   children?: React.ReactNode;
 }
 
-export const PreviewHost = (props: PreviewHostProps): JSX.Element => {
+export function PreviewHost(props: PreviewHostProps): JSX.Element {
+  if (process.env.NODE_ENV !== "development") {
+    return <>{props.children}</>;
+  }
+
+  return <PreviewHostImpl {...props} />;
+}
+
+export const PreviewHostImpl = (props: PreviewHostProps): JSX.Element => {
   const { children } = props;
 
   const client = useRozeniteDevToolsClient<PreviewPluginEventMap>({
@@ -31,13 +39,10 @@ export const PreviewHost = (props: PreviewHostProps): JSX.Element => {
       }
     );
 
-    const removePreviewClearListener = client.onMessage(
-      "preview-clear",
-      () => {
-        setPreviewName(null);
-        setComponent(null);
-      }
-    );
+    const removePreviewClearListener = client.onMessage("preview-clear", () => {
+      setPreviewName(null);
+      setComponent(null);
+    });
 
     return () => {
       removePreviewSelectListener.remove();

--- a/src/react-native/preview-registry.ts
+++ b/src/react-native/preview-registry.ts
@@ -3,7 +3,7 @@ import { getClient } from "./setup-plugin";
 
 const registry = new Map<string, Preview>();
 
-export function registerPreview(
+export async function registerPreview(
   name: string,
   component: React.ComponentType
 ): Promise<void>;

--- a/src/react-native/preview-registry.ts
+++ b/src/react-native/preview-registry.ts
@@ -33,7 +33,9 @@ export async function registerPreview(
   const client = await getClient();
 
   if (!client) {
-    // pendingRegistrations.push(entry);
+    console.warn(
+      `No Rozenite DevTools client found! Cannot register preview: ${name}`
+    );
     return;
   }
 

--- a/src/react-native/preview-registry.ts
+++ b/src/react-native/preview-registry.ts
@@ -1,34 +1,49 @@
-import { Preview } from "../shared/types";
-import { getClient, pendingRegistrations } from "./setup-plugin";
+import { Metadata, Preview } from "../shared/types";
+import { getClient } from "./setup-plugin";
 
-const previewRegistry = new Map<string, React.ComponentType>();
+const registry = new Map<string, Preview>();
 
-export async function registerPreview(
+export function registerPreview(
   name: string,
   component: React.ComponentType
+): Promise<void>;
+
+/**
+ * Register a preview component.
+ * @param name Preview name
+ * @param component React component
+ */
+export async function registerPreview(
+  name: string,
+  component: React.ComponentType,
+  /**
+   * This is injected by babel plugin
+   * @internal
+   */
+  metadata?: Metadata
 ) {
-  previewRegistry.set(name, component);
+  const entry: Preview = {
+    name,
+    component,
+    metadata,
+  };
+
+  registry.set(name, entry);
 
   const client = await getClient();
 
   if (!client) {
-    pendingRegistrations.push({ name, component });
+    // pendingRegistrations.push(entry);
     return;
   }
 
-  client.send("preview-added", {
-    name,
-    component,
-  });
+  client.send("preview-added", entry);
 }
 
 export function getPreviewComponents(): Preview[] {
-  return Array.from(previewRegistry.entries()).map(([name, component]) => ({
-    name,
-    component,
-  }));
+  return Array.from(registry.values());
 }
 
 export function getComponentByName(name: string) {
-  return previewRegistry.get(name);
+  return registry.get(name)?.component;
 }

--- a/src/react-native/preview-registry.ts
+++ b/src/react-native/preview-registry.ts
@@ -22,6 +22,13 @@ export async function registerPreview(
    */
   metadata?: Metadata
 ) {
+  if (metadata?.isInsideReactComponent) {
+    console.error(
+      `Cannot register preview "${name}" from inside a React component. Please call it at the top level of your module.`
+    );
+    return;
+  }
+
   const entry: Preview = {
     name,
     component,

--- a/src/react-native/preview-registry.ts
+++ b/src/react-native/preview-registry.ts
@@ -22,6 +22,10 @@ export async function registerPreview(
    */
   metadata?: Metadata
 ) {
+  if (process.env.NODE_ENV !== "development") {
+    return;
+  }
+
   if (metadata?.isInsideReactComponent) {
     console.error(
       `Cannot register preview "${name}" from inside a React component. Please call it at the top level of your module.`

--- a/src/react-native/setup-plugin.ts
+++ b/src/react-native/setup-plugin.ts
@@ -8,45 +8,49 @@ import { getPreviewComponents } from "./preview-registry";
 
 export let client: RozeniteDevToolsClient<PreviewPluginEventMap> | null = null;
 
-export const pendingRegistrations: Array<{
-  name: string;
-  component: React.ComponentType;
-}> = [];
-
 export const getClient = () => {
   return getRozeniteDevToolsClient<PreviewPluginEventMap>(PREVIEW_PLUGIN_ID);
 };
-
-function processPendingRegistrations() {
-  if (!client || pendingRegistrations.length === 0) {
-    return;
-  }
-
-  console.log(
-    `Processing ${pendingRegistrations.length} pending preview registrations`
-  );
-
-  pendingRegistrations.forEach(({ name, component }) => {
-    client!.send("preview-added", {
-      name,
-      component,
-    });
-  });
-
-  pendingRegistrations.length = 0;
-}
 
 async function setupPlugin() {
   const existingClient = await getClient();
 
   client = existingClient;
 
-  processPendingRegistrations();
-
   existingClient.onMessage("request-initial-data", () => {
     const previews = getPreviewComponents();
     existingClient.send("preview-list", previews);
+    console.log(`Sent initial preview list with entries`, previews);
   });
 }
 
+// function setupHMRListener() {
+//   if (!__DEV__) {
+//     return;
+//   }
+//   let isUpdating = false;
+//   DeviceEventEmitter.addListener("websocketMessage", (data) => {
+//     try {
+//       const response = JSON.parse(data.data);
+//       if (response.type === "update" && response.body?.modified?.length > 0) {
+//         isUpdating = true;
+//       }
+
+//       if (isUpdating && response?.type === "update-done") {
+//         isUpdating = false;
+//         // Do your changes here!
+//         console.log("HMR update done, reloading previews...");
+//         console.log("Detected removed components, updating registry...");
+//         import("./preview-registry").then(({ detectRemovedComponents }) => {
+//           detectRemovedComponents();
+//         });
+//       }
+//     } catch (e) {
+//       console.log("Failed to parse the webSocketMessage event data!", e);
+//     }
+//   });
+// }
+
 setupPlugin();
+
+// setupHMRListener();

--- a/src/react-native/setup-plugin.ts
+++ b/src/react-native/setup-plugin.ts
@@ -20,37 +20,7 @@ async function setupPlugin() {
   existingClient.onMessage("request-initial-data", () => {
     const previews = getPreviewComponents();
     existingClient.send("preview-list", previews);
-    console.log(`Sent initial preview list with entries`, previews);
   });
 }
 
-// function setupHMRListener() {
-//   if (!__DEV__) {
-//     return;
-//   }
-//   let isUpdating = false;
-//   DeviceEventEmitter.addListener("websocketMessage", (data) => {
-//     try {
-//       const response = JSON.parse(data.data);
-//       if (response.type === "update" && response.body?.modified?.length > 0) {
-//         isUpdating = true;
-//       }
-
-//       if (isUpdating && response?.type === "update-done") {
-//         isUpdating = false;
-//         // Do your changes here!
-//         console.log("HMR update done, reloading previews...");
-//         console.log("Detected removed components, updating registry...");
-//         import("./preview-registry").then(({ detectRemovedComponents }) => {
-//           detectRemovedComponents();
-//         });
-//       }
-//     } catch (e) {
-//       console.log("Failed to parse the webSocketMessage event data!", e);
-//     }
-//   });
-// }
-
 setupPlugin();
-
-// setupHMRListener();

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,7 +1,20 @@
+export interface Metadata {
+  id: string;
+  name: string | null;
+  nameType: "literal" | "identifier" | "template";
+  callId: string;
+  line: number;
+  column: number;
+  componentType: string | null;
+  timestamp: number;
+  relativeFilename: string | null;
+  filePath: string | null;
+}
+
 export interface Preview {
   component: React.ComponentType;
   name: string;
-  path?: string; // TODO: Path to the component file
+  metadata?: Metadata;
 }
 
 export type DevToolsActionType =

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,7 +6,6 @@ export interface Metadata {
   line: number;
   column: number;
   componentType: string | null;
-  timestamp: number;
   relativeFilename: string | null;
   filePath: string | null;
   isInsideReactComponent: boolean; 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -9,6 +9,7 @@ export interface Metadata {
   timestamp: number;
   relativeFilename: string | null;
   filePath: string | null;
+  isInsideReactComponent: boolean; 
 }
 
 export interface Preview {

--- a/src/ui/preview-panel.css
+++ b/src/ui/preview-panel.css
@@ -278,3 +278,22 @@
 .content::-webkit-scrollbar-thumb:hover {
   background: #4a4a4a;
 }
+
+.vscode-btn {
+  background: transparent;
+  border: none;
+  color: #cccccc;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.vscode-btn:hover {
+  background: #404040;
+}
+.vscode-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/ui/preview-panel.tsx
+++ b/src/ui/preview-panel.tsx
@@ -1,5 +1,5 @@
 import { useRozeniteDevToolsClient } from "@rozenite/plugin-bridge";
-import { Code, Eye, Package, Play, RefreshCw, Search } from "lucide-react";
+import { Code, Eye, FileCode, Package, Play, RefreshCw, Search } from "lucide-react";
 import { useEffect, useState } from "react";
 import { PreviewPluginEventMap } from "../shared/messaging";
 import { Preview, PREVIEW_PLUGIN_ID } from "../shared/types";
@@ -210,7 +210,7 @@ export default function PreviewPanel() {
                     navigateToFileInVscode(preview);
                   }}
                 >
-                  <Eye size={12} />
+                  <FileCode size={12} />
                 </button>
               </div>
             ))}

--- a/src/ui/preview-panel.tsx
+++ b/src/ui/preview-panel.tsx
@@ -1,12 +1,5 @@
 import { useRozeniteDevToolsClient } from "@rozenite/plugin-bridge";
-import {
-  Code,
-  Eye,
-  Package,
-  Play,
-  RefreshCw,
-  Search
-} from "lucide-react";
+import { Code, Eye, Package, Play, RefreshCw, Search } from "lucide-react";
 import { useEffect, useState } from "react";
 import { PreviewPluginEventMap } from "../shared/messaging";
 import { Preview, PREVIEW_PLUGIN_ID } from "../shared/types";
@@ -79,6 +72,29 @@ export default function PreviewPanel() {
     setIsRefreshing(true);
     client.send("request-initial-data", {});
     setTimeout(() => setIsRefreshing(false), 500);
+  };
+
+  const getPathWithLineAndColumn = (preview: Preview) => {
+    if (!preview.metadata?.filePath) {
+      return preview.metadata?.relativeFilename || "Unknown path";
+    }
+
+    const { relativeFilename, line, column } = preview.metadata;
+
+    return `${relativeFilename}${line ? `:${line}` : ""}${
+      column ? `:${column}` : ""
+    }`;
+  };
+
+  const navigateToFileInVscode = (preview: Preview) => {
+    if (!preview.metadata?.filePath) return;
+
+    const { filePath, line, column } = preview.metadata;
+    const vscodeUrl = `vscode://file/${filePath}${line ? `:${line}` : ""}${
+      column ? `:${column}` : ""
+    }`;
+
+    window.open(vscodeUrl, "_blank");
   };
 
   return (
@@ -177,12 +193,23 @@ export default function PreviewPanel() {
                     <Code className="component-icon" size={16} />
                     <span className="component-name">{preview.name}</span>
                   </div>
-                  {preview.path && (
-                    <div className="component-path">{preview.path}</div>
+                  {preview.metadata && (
+                    <div className="component-path">
+                      {getPathWithLineAndColumn(preview)}
+                    </div>
                   )}
                 </div>
                 <button className="preview-btn" title="Preview component">
                   <Play size={12} />
+                </button>
+                <button
+                  className="vscode-btn"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    navigateToFileInVscode(preview);
+                  }}
+                >
+                  <Eye size={12} />
                 </button>
               </div>
             ))}

--- a/src/ui/preview-panel.tsx
+++ b/src/ui/preview-panel.tsx
@@ -1,8 +1,16 @@
 import { useRozeniteDevToolsClient } from "@rozenite/plugin-bridge";
-import { Code, Eye, FileCode, Package, Play, RefreshCw, Search } from "lucide-react";
+import {
+  Code,
+  Eye,
+  FileCode,
+  Package,
+  Play,
+  RefreshCw,
+  Search,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import { PreviewPluginEventMap } from "../shared/messaging";
-import { Preview, PREVIEW_PLUGIN_ID } from "../shared/types";
+import { Metadata, Preview, PREVIEW_PLUGIN_ID } from "../shared/types";
 import "./preview-panel.css";
 
 export default function PreviewPanel() {
@@ -74,22 +82,16 @@ export default function PreviewPanel() {
     setTimeout(() => setIsRefreshing(false), 500);
   };
 
-  const getPathWithLineAndColumn = (preview: Preview) => {
-    if (!preview.metadata?.filePath) {
-      return preview.metadata?.relativeFilename || "Unknown path";
-    }
-
-    const { relativeFilename, line, column } = preview.metadata;
+  const getPathWithLineAndColumn = (metadata: Metadata) => {
+    const { relativeFilename, line, column } = metadata;
 
     return `${relativeFilename}${line ? `:${line}` : ""}${
       column ? `:${column}` : ""
     }`;
   };
 
-  const navigateToFileInVscode = (preview: Preview) => {
-    if (!preview.metadata?.filePath) return;
-
-    const { filePath, line, column } = preview.metadata;
+  const navigateToFileInVscode = (metadata: Metadata) => {
+    const { filePath, line, column } = metadata;
     const vscodeUrl = `vscode://file/${filePath}${line ? `:${line}` : ""}${
       column ? `:${column}` : ""
     }`;
@@ -195,23 +197,27 @@ export default function PreviewPanel() {
                   </div>
                   {preview.metadata && (
                     <div className="component-path">
-                      {getPathWithLineAndColumn(preview)}
+                      {getPathWithLineAndColumn(preview.metadata)}
                     </div>
                   )}
                 </div>
                 <button className="preview-btn" title="Preview component">
                   <Play size={12} />
                 </button>
-                <button
-                  className="vscode-btn"
-                  title="Open in VS Code"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    navigateToFileInVscode(preview);
-                  }}
-                >
-                  <FileCode size={12} />
-                </button>
+                {preview.metadata && (
+                  <button
+                    className="vscode-btn"
+                    title="Open in VS Code"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (preview.metadata) {
+                        navigateToFileInVscode(preview.metadata);
+                      }
+                    }}
+                  >
+                    <FileCode size={12} />
+                  </button>
+                )}
               </div>
             ))}
           </div>

--- a/src/ui/preview-panel.tsx
+++ b/src/ui/preview-panel.tsx
@@ -204,6 +204,7 @@ export default function PreviewPanel() {
                 </button>
                 <button
                   className="vscode-btn"
+                  title="Open in VS Code"
                   onClick={(e) => {
                     e.stopPropagation();
                     navigateToFileInVscode(preview);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,12 +14,14 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "stripInternal": true
   },
   "include": [
     "src/**/*",
     "react-native.ts",
-    "rozenite.config.ts"
+    "rozenite.config.ts",
+    "babel-plugin/preview-babel-plugin-metadata.cjs"
   ],
   "exclude": ["node_modules", "dist", "build"]
 }


### PR DESCRIPTION
This PR adds a Babel plugin that injects metadata into `registerPreview()` calls in Rozenite Preview. It captures file path, line, column, and other details, enabling better tracking and tooling support.

Key changes:

* **New Babel plugin** (`preview-babel-plugin-metadata.cjs`) adds metadata automatically.
* **DevTools panel** now shows file locations and adds a "View in VSCode" button.
* **`registerPreview`** updated to accept injected metadata by babel and warn if called inside a React component.
* **README updated** with babel configuration and HMR limitations.
* **Type and config updates** to support the new plugin and metadata handling.
