### PR TITLE
feat: add support for metro HMR

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,6 @@ export default function App() {
 
 https://github.com/user-attachments/assets/dffe5803-fb6a-4b45-9621-48cbbdb25ad2
 
-## Known Issues
-
-- **HMR Support**: Hot Module Replacement (HMR) is not fully supported yet. You need to refresh the DevTools to see changes in deleted previews. Adding or modifying previews works for now.
-
 ## API
 
 - `registerPreview(name: string, component: React.ComponentType)`

--- a/babel-plugin/preview-babel-plugin-metadata.cjs
+++ b/babel-plugin/preview-babel-plugin-metadata.cjs
@@ -1,28 +1,16 @@
 const path = require("path");
-const crypto = require("crypto");
+
 const { isInsideReactComponent } = require("./react-helper.cjs");
 
 /**
- * Babel plugin that automatically injects the file path and other metadata
- * to registerPreview() calls imported from "rozenite-preview"
+ * Babel plugin that automatically injects file path, relative filename,
+ * React component context, name, call site location, and other metadata
+ * into registerPreview() calls imported from "rozenite-preview".
+ * Also injects the Metro "module" object as the first argument.
  */
 const ROZENITE_PREVIEW_MODULE = "rozenite-preview";
 const TARGET_FUNCTION = "registerPreview";
 const EXPECTED_ARGS_COUNT = 2;
-
-const cache = {};
-
-function getOrCreateId(file, line) {
-  const key = `${file}:${line}`;
-  if (cache[key]) return cache[key];
-
-  const hash = crypto.createHash("md5").update(key).digest("hex").slice(0, 6);
-  const id = `${path
-    .basename(file, path.extname(file))
-    .toLowerCase()}_${line}_${hash}`;
-  cache[key] = id;
-  return id;
-}
 
 module.exports = function ({ types: t }) {
   return {
@@ -34,18 +22,20 @@ module.exports = function ({ types: t }) {
           return;
         }
 
-        injectFilePathIntoRegisterPreviewCalls(
-          path,
-          state,
-          rozenitePreviewImports,
-          t
-        );
+        if (isTargetRegisterPreviewCall(callPath, rozenitePreviewImports)) {
+          injectFilePathIntoRegisterPreviewCalls(
+            path,
+            state,
+            rozenitePreviewImports,
+            t
+          );
 
-        injectMetroModuleIntoRegisterPreviewCalls(
-          path,
-          rozenitePreviewImports,
-          t
-        );
+          injectMetroModuleIntoRegisterPreviewCalls(
+            path,
+            rozenitePreviewImports,
+            t
+          );
+        }
       },
     },
   };
@@ -103,62 +93,46 @@ function isValidImportSpecifier(specifier, t) {
  * Traverses the AST and injects file paths into registerPreview calls
  * @param {Object} programPath - The program AST path
  * @param {Object} state - Babel plugin state
- * @param {Set} rozenitePreviewImports - Set of imported identifiers from rozenite-preview
  * @param {Object} t - Babel types helper
  */
-function injectFilePathIntoRegisterPreviewCalls(
-  programPath,
-  state,
-  rozenitePreviewImports,
-  t
-) {
+function injectFilePathIntoRegisterPreviewCalls(programPath, state, t) {
   const filename = state.file.opts.filename || "";
   const relativeFilename = path.relative(process.cwd(), filename);
 
   programPath.traverse({
     CallExpression(callPath) {
-      if (isTargetRegisterPreviewCall(callPath, rozenitePreviewImports)) {
-        const metadata = getMetadata(callPath);
-        const filePath = t.stringLiteral(filename);
-        const id = getOrCreateId(relativeFilename, metadata.line);
-        const argument = t.objectExpression([
-          t.objectProperty(t.identifier("id"), t.stringLiteral(id)),
-          t.objectProperty(t.identifier("filePath"), filePath),
-          t.objectProperty(
-            t.identifier("relativeFilename"),
-            t.stringLiteral(relativeFilename)
-          ),
-          t.objectProperty(
-            t.identifier("isInsideReactComponent"),
-            t.booleanLiteral(isInsideReactComponent(callPath))
-          ),
-          t.objectProperty(
-            t.identifier("name"),
-            t.stringLiteral(metadata.name)
-          ),
-          t.objectProperty(
-            t.identifier("nameType"),
-            t.stringLiteral(metadata.nameType)
-          ),
-          t.objectProperty(
-            t.identifier("callId"),
-            t.stringLiteral(metadata.callId)
-          ),
-          t.objectProperty(
-            t.identifier("componentType"),
-            t.stringLiteral(metadata.componentType)
-          ),
-          t.objectProperty(
-            t.identifier("line"),
-            t.numericLiteral(metadata.line)
-          ),
-          t.objectProperty(
-            t.identifier("column"),
-            t.numericLiteral(metadata.column)
-          ),
-        ]);
-        callPath.node.arguments.push(argument);
-      }
+      const metadata = getMetadata(callPath);
+      const filePath = t.stringLiteral(filename);
+      const argument = t.objectExpression([
+        t.objectProperty(t.identifier("filePath"), filePath),
+        t.objectProperty(
+          t.identifier("relativeFilename"),
+          t.stringLiteral(relativeFilename)
+        ),
+        t.objectProperty(
+          t.identifier("isInsideReactComponent"),
+          t.booleanLiteral(isInsideReactComponent(callPath))
+        ),
+        t.objectProperty(t.identifier("name"), t.stringLiteral(metadata.name)),
+        t.objectProperty(
+          t.identifier("nameType"),
+          t.stringLiteral(metadata.nameType)
+        ),
+        t.objectProperty(
+          t.identifier("callId"),
+          t.stringLiteral(metadata.callId)
+        ),
+        t.objectProperty(
+          t.identifier("componentType"),
+          t.stringLiteral(metadata.componentType)
+        ),
+        t.objectProperty(t.identifier("line"), t.numericLiteral(metadata.line)),
+        t.objectProperty(
+          t.identifier("column"),
+          t.numericLiteral(metadata.column)
+        ),
+      ]);
+      callPath.node.arguments.push(argument);
     },
   });
 }
@@ -224,32 +198,27 @@ function getMetadata(callPath) {
  * @param {Set} rozenitePreviewImports - Set of imported identifiers from rozenite-preview
  * @returns {boolean}
  */
-function isTargetRegisterPreviewCall(
-  callPath,
-  rozenitePreviewImports,
-  expectedArgs = EXPECTED_ARGS_COUNT
-) {
+function isTargetRegisterPreviewCall(callPath, rozenitePreviewImports) {
   const callee = callPath.get("callee");
 
   return (
     callee.isIdentifier() &&
     callee.node.name === TARGET_FUNCTION &&
     rozenitePreviewImports.has(callee.node.name) &&
-    callPath.node.arguments.length === expectedArgs
+    callPath.node.arguments.length === EXPECTED_ARGS_COUNT
   );
 }
 
-function injectMetroModuleIntoRegisterPreviewCalls(
-  programPath,
-  rozenitePreviewImports,
-  t
-) {
+/**
+ * Injects the Metro module into all registerPreview calls as the first argument.
+ * @param programPath
+ * @param t
+ */
+function injectMetroModuleIntoRegisterPreviewCalls(programPath, t) {
   programPath.traverse({
     CallExpression(callPath) {
-      if (isTargetRegisterPreviewCall(callPath, rozenitePreviewImports, 3)) {
-        const { node } = callPath;
-        node.arguments.unshift(t.identifier("module"));
-      }
+      const { node } = callPath;
+      node.arguments.unshift(t.identifier("module"));
     },
   });
 }

--- a/babel-plugin/preview-babel-plugin-metadata.cjs
+++ b/babel-plugin/preview-babel-plugin-metadata.cjs
@@ -22,7 +22,7 @@ module.exports = function ({ types: t }) {
           return;
         }
 
-        if (isTargetRegisterPreviewCall(callPath, rozenitePreviewImports)) {
+        if (isTargetRegisterPreviewCall(path, rozenitePreviewImports)) {
           injectFilePathIntoRegisterPreviewCalls(path, state, t);
 
           injectMetroModuleIntoRegisterPreviewCalls(path, t);

--- a/babel-plugin/preview-babel-plugin-metadata.cjs
+++ b/babel-plugin/preview-babel-plugin-metadata.cjs
@@ -23,18 +23,9 @@ module.exports = function ({ types: t }) {
         }
 
         if (isTargetRegisterPreviewCall(callPath, rozenitePreviewImports)) {
-          injectFilePathIntoRegisterPreviewCalls(
-            path,
-            state,
-            rozenitePreviewImports,
-            t
-          );
+          injectFilePathIntoRegisterPreviewCalls(path, state, t);
 
-          injectMetroModuleIntoRegisterPreviewCalls(
-            path,
-            rozenitePreviewImports,
-            t
-          );
+          injectMetroModuleIntoRegisterPreviewCalls(path, t);
         }
       },
     },

--- a/src/react-native/preview-host.tsx
+++ b/src/react-native/preview-host.tsx
@@ -39,14 +39,14 @@ export const PreviewHostImpl = (props: PreviewHostProps): JSX.Element => {
       }
     );
 
-    const removePreviewClearListener = client.onMessage("preview-clear", () => {
+    const showMainAppListener = client.onMessage("show-main-app", () => {
       setPreviewName(null);
       setComponent(null);
     });
 
     return () => {
       removePreviewSelectListener.remove();
-      removePreviewClearListener.remove();
+      showMainAppListener.remove();
     };
   }, [client]);
 

--- a/src/react-native/preview-registry.ts
+++ b/src/react-native/preview-registry.ts
@@ -8,21 +8,16 @@ const registry = createSignalMap<number, Preview[]>(() => {
   client?.send("registry-updated", previews);
 });
 
+function flattenRegistryEntries() {
+  return Array.from(registry.values()).flat();
+}
+
 export function getPreviewComponents(): Preview[] {
-  return Array.from(registry.values()).flatMap((entry) =>
-    entry.map((e) => ({
-      name: e.name,
-      component: e.component,
-      metadata: e.metadata,
-    }))
-  );
+  return flattenRegistryEntries();
 }
 
 export function getComponentByName(name: string) {
-  const previews = Array.from(registry.values())
-    .flatMap((entry) => entry)
-    .find((e) => e.name === name);
-  return previews?.component;
+  return flattenRegistryEntries().find((entry) => entry.name === name)?.component || null;
 }
 
 /**

--- a/src/react-native/preview-registry.ts
+++ b/src/react-native/preview-registry.ts
@@ -26,7 +26,7 @@ export function getComponentByName(name: string) {
 }
 
 /**
- * 
+ *
  * @internal
  */
 const __registerPreviewInternal = (
@@ -42,6 +42,13 @@ const __registerPreviewInternal = (
   ) {
     console.warn(
       `Cannot register preview "${name}" in production or in non Metro environment.`
+    );
+    return;
+  }
+
+  if (metadata?.isInsideReactComponent) {
+    console.error(
+      'Do not call "registerPreview" inside a React lifecycle. Use it at the top level of your module.'
     );
     return;
   }

--- a/src/react-native/preview-registry.ts
+++ b/src/react-native/preview-registry.ts
@@ -78,7 +78,7 @@ const __registerPreviewInternal = (
  * @param name Preview name
  * @param component React component
  */
-export function registerPreview(name: string, component: React.ComponentType) {
+export function registerPreview(name: string, component: React.ComponentType) {  
   __registerPreviewInternal(
     ...(arguments as unknown as [MetroModule, string, ComponentType, Metadata])
   );

--- a/src/react-native/setup-plugin.ts
+++ b/src/react-native/setup-plugin.ts
@@ -8,7 +8,7 @@ import { getPreviewComponents } from "./preview-registry";
 
 export let client: RozeniteDevToolsClient<PreviewPluginEventMap> | null = null;
 
-export const getClient = () => {
+const getClient = () => {
   return getRozeniteDevToolsClient<PreviewPluginEventMap>(PREVIEW_PLUGIN_ID);
 };
 
@@ -19,7 +19,6 @@ async function setupPlugin() {
 
   existingClient.onMessage("request-initial-data", () => {
     const previews = getPreviewComponents();
-    console.log(`Sending initial preview data: ${previews.length} previews found`, previews);
     existingClient.send("registry-updated", previews);
   });
 }

--- a/src/react-native/setup-plugin.ts
+++ b/src/react-native/setup-plugin.ts
@@ -19,7 +19,8 @@ async function setupPlugin() {
 
   existingClient.onMessage("request-initial-data", () => {
     const previews = getPreviewComponents();
-    existingClient.send("preview-list", previews);
+    console.log(`Sending initial preview data: ${previews.length} previews found`, previews);
+    existingClient.send("registry-updated", previews);
   });
 }
 

--- a/src/shared/messaging.ts
+++ b/src/shared/messaging.ts
@@ -3,9 +3,8 @@ import { Preview } from "./types";
 
 export type PreviewPluginEventMap = {
   "request-initial-data": unknown;
-  "preview-clear": unknown;
-  "preview-list": Preview[];
-  "preview-added": Preview;
+  "show-main-app": unknown;
+  "registry-updated": Preview[];
   "preview-select": {
     name: string;
   };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -8,7 +8,7 @@ export interface Metadata {
   componentType: string | null;
   relativeFilename: string | null;
   filePath: string | null;
-  isInsideReactComponent: boolean; 
+  isInsideReactComponent: boolean;
 }
 
 export interface Preview {
@@ -17,14 +17,25 @@ export interface Preview {
   metadata?: Metadata;
 }
 
-export type DevToolsActionType =
-  | "preview:list" // DevTools → App: Request list of previewable components
-  | "preview:list-response" // App → DevTools: Send back the list
-  | "preview:select" // DevTools → App: Select and render a specific component
-  | "preview:clear" // DevTools → App: Clear the current preview
-  | "preview:update-props" // DevTools → App: Update props passed to previewed component
-  | "preview:get-current" // DevTools → App: Ask which component is currently previewed
-  | "preview:current-response" // App → DevTools: Respond with currently previewed component
-  | "preview:error"; // App → DevTools: Report an error (e.g. component not found)
-
 export const PREVIEW_PLUGIN_ID = "rozenite-preview";
+
+type HotModuleReloadingCallback = () => void;
+
+type HotModuleReloadingData = {
+  _acceptCallback?: HotModuleReloadingCallback;
+  _disposeCallback?: HotModuleReloadingCallback;
+  _didAccept: boolean;
+  accept: (callback?: HotModuleReloadingCallback) => void;
+  dispose: (callback?: HotModuleReloadingCallback) => void;
+};
+
+type ModuleID = number;
+
+type Exports = any;
+
+// https://github.com/facebook/metro/blob/a81c99cf103be00181aa635fef94c6e3385a47bb/packages/metro-runtime/src/polyfills/require.js#L51
+export type MetroModule = {
+  id?: ModuleID;
+  exports: Exports;
+  hot?: HotModuleReloadingData;
+};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -33,7 +33,7 @@ type ModuleID = number;
 
 type Exports = any;
 
-// https://github.com/facebook/metro/blob/a81c99cf103be00181aa635fef94c6e3385a47bb/packages/metro-runtime/src/polyfills/require.js#L51
+// Ref: https://github.com/facebook/metro/blob/a81c99cf103be00181aa635fef94c6e3385a47bb/packages/metro-runtime/src/polyfills/require.js#L51
 export type MetroModule = {
   id?: ModuleID;
   exports: Exports;

--- a/src/ui/preview-panel.tsx
+++ b/src/ui/preview-panel.tsx
@@ -31,10 +31,6 @@ export default function PreviewPanel() {
   );
 
   useEffect(() => {
-    if (!client) {
-      return;
-    }
-
     if (!client) return;
 
     const previewListSubscription = client.onMessage(

--- a/src/ui/preview-panel.tsx
+++ b/src/ui/preview-panel.tsx
@@ -37,26 +37,14 @@ export default function PreviewPanel() {
 
     if (!client) return;
 
-    const previewSubscription = client.onMessage("preview-added", (preview) => {
-      setPreviews((prev) => {
-        const existingIndex = prev.findIndex((p) => p.name === preview.name);
-        if (existingIndex !== -1) {
-          const updated = [...prev];
-          updated[existingIndex] = preview;
-          return updated;
-        }
-        return [...prev, preview];
-      });
-    });
-
-    const previewListSubscription = client.onMessage("preview-list", (data) => {
-      setPreviews(data);
-    });
+    const previewListSubscription = client.onMessage(
+      "registry-updated",
+      setPreviews
+    );
 
     client.send("request-initial-data", {});
 
     return () => {
-      previewSubscription.remove();
       previewListSubscription.remove();
     };
   }, [client]);
@@ -71,7 +59,7 @@ export default function PreviewPanel() {
   const showMainApp = () => {
     if (!client) return;
 
-    client.send("preview-clear", {});
+    client.send("show-main-app", {});
   };
 
   const refreshPreviews = async () => {

--- a/src/utils/signal-map.ts
+++ b/src/utils/signal-map.ts
@@ -1,0 +1,46 @@
+export function createSignalMap<K, V>(
+  onChange: (type: 'set' | 'delete' | 'clear', key?: K, value?: V) => void
+) {
+  const internal = new Map<K, V>();
+
+  return {
+    set(key: K, value: V) {
+      internal.set(key, value);
+      onChange('set', key, value);
+      return this;
+    },
+    delete(key: K) {
+      const existed = internal.delete(key);
+      if (existed) onChange('delete', key);
+      return existed;
+    },
+    clear() {
+      internal.clear();
+      onChange('clear');
+    },
+    get(key: K) {
+      return internal.get(key);
+    },
+    has(key: K) {
+      return internal.has(key);
+    },
+    get size() {
+      return internal.size;
+    },
+    [Symbol.iterator]() {
+      return internal[Symbol.iterator]();
+    },
+    entries() {
+      return internal.entries();
+    },
+    keys() {
+      return internal.keys();
+    },
+    values() {
+      return internal.values();
+    },
+    forEach(cb: (value: V, key: K, map: Map<K, V>) => void) {
+      internal.forEach(cb);
+    }
+  } as Map<K, V>;
+}

--- a/src/utils/signal-map.ts
+++ b/src/utils/signal-map.ts
@@ -1,22 +1,22 @@
 export function createSignalMap<K, V>(
-  onChange: (type: 'set' | 'delete' | 'clear', key?: K, value?: V) => void
+  onChange: (type: "set" | "delete" | "clear", key?: K, value?: V) => void
 ) {
   const internal = new Map<K, V>();
 
   return {
     set(key: K, value: V) {
       internal.set(key, value);
-      onChange('set', key, value);
+      onChange("set", key, value);
       return this;
     },
     delete(key: K) {
       const existed = internal.delete(key);
-      if (existed) onChange('delete', key);
+      if (existed) onChange("delete", key);
       return existed;
     },
     clear() {
       internal.clear();
-      onChange('clear');
+      onChange("clear");
     },
     get(key: K) {
       return internal.get(key);
@@ -41,6 +41,6 @@ export function createSignalMap<K, V>(
     },
     forEach(cb: (value: V, key: K, map: Map<K, V>) => void) {
       internal.forEach(cb);
-    }
-  } as Map<K, V>;
+    },
+  };
 }


### PR DESCRIPTION
This PR implements full Hot Module Replacement (HMR) support for preview components in Metro, enabling reliable updates, additions, and deletions during development without requiring DevTools refreshes.

- Cleaned up legacy behavior: Removed old preview-added, preview-list, and preview-clear message handlers and replaced them with a single registry-updated event.
- On any preview registration change (add/update/delete), the entire preview registry is pushed to DevTools automatically.
- No more manual DevTools refresh to remove stale previews.

Clean separation of internal vs. external API (`__registerPreviewInternal` used only with `module` passed from Babel).
